### PR TITLE
fix!: Add missing "ci" type from use_angular

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -359,9 +359,9 @@ sizes:
   If you include the `use_angular: true` key in your sizes, then the
   following angular conventions will be added to your sizes: `major: [
   "!" ]`, `minor: [ feat ]`, `patch: [ fix ]`, and `none: [ docs,
-  style, refactor, perf, test, chore, build ]`. You can override these
-  by placing those specific types in different properties (as `docs` is
-  done here).
+  style, refactor, perf, test, chore, build, ci ]`. You can override 
+  these by placing those specific types in different properties (as 
+  `docs` is done here).
 
   "!" is a special type which matches a commit whose type ends with "!"
   (as in `refactor!: remove NodeJS 6 support` or `chore(toil)!: delete

--- a/src/config.rs
+++ b/src/config.rs
@@ -1200,6 +1200,7 @@ fn insert_angular(result: &mut HashMap<String, Size>) {
   insert_if_missing(result, "test", Size::None);
   insert_if_missing(result, "chore", Size::None);
   insert_if_missing(result, "build", Size::None);
+  insert_if_missing(result, "ci", Size::None);
 }
 
 fn insert_if_missing(result: &mut HashMap<String, Size>, key: &str, val: Size) {
@@ -1486,6 +1487,28 @@ sizes:
 "#;
 
     assert!(ConfigFile::read(config).is_err());
+  }
+
+  #[test]
+  fn test_angular_sizes() {
+    let config = r#"
+projects: []
+sizes:
+  use_angular: true
+"#;
+
+    let config = ConfigFile::read(config).unwrap();
+    assert_eq!(&Size::Major, config.sizes.get("!").unwrap());
+    assert_eq!(&Size::Minor, config.sizes.get("feat").unwrap());
+    assert_eq!(&Size::Patch, config.sizes.get("fix").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("docs").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("style").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("refactor").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("perf").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("test").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("chore").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("build").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("ci").unwrap());
   }
 
   #[test]


### PR DESCRIPTION
We're missing a "ci" type from the angular types list. This is
documented on the [Angluar Contributing][1] page.

Marked as a BC Breaking change, as it will break people's
config who have manually added this type.

[1]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md