### PR TITLE
fix!: Remove deprecated keys

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -358,10 +358,10 @@ sizes:
 
   If you include the `use_angular: true` key in your sizes, then the
   following angular conventions will be added to your sizes: `major: [
-  "!" ]`, `minor: [ feat ]`, `patch: [ fix ]`, and `none: [ docs,
-  style, refactor, perf, test, chore, build ]`. You can override these
-  by placing those specific types in different properties (as `docs` is
-  done here).
+  "!" ]`, `minor: [ feat ]`, `patch: [ fix ]`, and `none: [ docs, 
+  refactor, perf, test, build ]`. You can override these by placing 
+  those specific types in different properties (as `docs` is done 
+  here).
 
   "!" is a special type which matches a commit whose type ends with "!"
   (as in `refactor!: remove NodeJS 6 support` or `chore(toil)!: delete

--- a/src/config.rs
+++ b/src/config.rs
@@ -1194,11 +1194,9 @@ fn insert_angular(result: &mut HashMap<String, Size>) {
   insert_if_missing(result, "feat", Size::Minor);
   insert_if_missing(result, "fix", Size::Patch);
   insert_if_missing(result, "docs", Size::None);
-  insert_if_missing(result, "style", Size::None);
   insert_if_missing(result, "refactor", Size::None);
   insert_if_missing(result, "perf", Size::None);
   insert_if_missing(result, "test", Size::None);
-  insert_if_missing(result, "chore", Size::None);
   insert_if_missing(result, "build", Size::None);
 }
 
@@ -1452,6 +1450,25 @@ projects:
     "#;
 
     assert!(ConfigFile::read(config).is_ok());
+  }
+
+  #[test]
+  fn test_angular_sizes() {
+    let config = r#"
+projects: []
+sizes:
+  use_angular: true
+"#;
+
+    let config = ConfigFile::read(config).unwrap();
+    assert_eq!(&Size::Major, config.sizes.get("!").unwrap());
+    assert_eq!(&Size::Minor, config.sizes.get("feat").unwrap());
+    assert_eq!(&Size::Patch, config.sizes.get("fix").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("docs").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("refactor").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("perf").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("test").unwrap());
+    assert_eq!(&Size::None, config.sizes.get("build").unwrap());
   }
 
   #[test]


### PR DESCRIPTION
The [Angular Convention][1] no longer uses these keys.

BREAKING CHANGE as this may mean that people using the default are not
able to use these key as expected.

(Note: It might be better just to leave these in, I mostly had added this for "completeness" as a counterpoint to #4)
[1]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md
