### PR TITLE
fix: add "exact" flag

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -125,6 +125,8 @@ along with their options and flags. You can always use `versio help` or
   - `--version-only` (`-v`): Output only the version number(s)
   - `--name` (`-n <name>`): Show only the project(s) whose name at least
     partially matches. Mutually exclusive with `id`.
+  - `--exact` (`-e <name>`): Like `name`, but matches exactly. Mututally
+    exclusive with `id` and `name`.
   - `--prev` (`-p`): Show the previous versions instead, created by the
     last run of `versio run`. This will differ from the current version
     if you have added/removed projects, or manually made version number
@@ -137,6 +139,8 @@ along with their options and flags. You can always use `versio help` or
   - `--id` (`-i <ID>`): Change the project that matches the given ID.
   - `--name` (`-n <name>`): Change the project that matches the given
     name.
+  - `--exact` (`-e <name>`): Like `name`, but matches exactly. Mututally
+    exclusive with `id` and `name`.
   - `--value` (`-v <value>`): The new version value
 
   If you only have a single project configured, you don't need to
@@ -157,6 +161,7 @@ along with their options and flags. You can always use `versio help` or
     can provide this option more than once).
   - `--name` (`-n <name>`): include a named project in the document (you
     can provide this option more than once).
+  - `--exact` (`-e <name>`): Like `name`, but matches exactly.
   - `--label` (`-l <label>`): include all projects with a label (you can
     provide this option more than once).
   - `--all` (`-a`): include all projects.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -60,7 +60,7 @@ pub fn check(pref_vcs: Option<VcsRange>, ignore_current: bool) -> Result<()> {
 }
 
 pub fn get(
-  pref_vcs: Option<VcsRange>, wide: bool, versonly: bool, prev: bool, id: Option<&str>, name: Option<&str>,
+  pref_vcs: Option<VcsRange>, wide: bool, versonly: bool, prev: bool, id: Option<&str>, name: &NameMatch,
   ignore_current: bool
 ) -> Result<()> {
   let mono = with_opts(pref_vcs, VcsLevel::None, VcsLevel::Local, VcsLevel::None, VcsLevel::Smart, ignore_current)?;
@@ -73,7 +73,7 @@ pub fn get(
 }
 
 fn get_using_cfg<R: StateRead>(
-  cfg: &Config<R>, wide: bool, versonly: bool, id: Option<&str>, name: Option<&str>
+  cfg: &Config<R>, wide: bool, versonly: bool, id: Option<&str>, name: &NameMatch
 ) -> Result<()> {
   let output = Output::new();
   let mut output = output.projects(wide, versonly);
@@ -84,8 +84,11 @@ fn get_using_cfg<R: StateRead>(
   if let Some(id) = id {
     let id = id.parse()?;
     output.write_project(ProjLine::from(cfg.get_project(&id).ok_or_else(&ensure)?, reader)?)?;
-  } else if let Some(name) = name {
+  } else if let NameMatch::Partial(name) = name {
     let id = cfg.find_unique(name)?;
+    output.write_project(ProjLine::from(cfg.get_project(id).ok_or_else(&ensure)?, reader)?)?;
+  } else if let NameMatch::Exact(name) = name {
+    let id = cfg.find_exact(name)?;
     output.write_project(ProjLine::from(cfg.get_project(id).ok_or_else(&ensure)?, reader)?)?;
   } else {
     if cfg.projects().len() != 1 {
@@ -116,13 +119,15 @@ fn show_using_cfg<R: StateRead>(cfg: &Config<R>, wide: bool) -> Result<()> {
   output.commit()
 }
 
-pub fn set(pref_vcs: Option<VcsRange>, id: Option<&str>, name: Option<&str>, value: &str) -> Result<()> {
+pub fn set(pref_vcs: Option<VcsRange>, id: Option<&str>, name: &NameMatch, value: &str) -> Result<()> {
   let mut mono = build(pref_vcs, VcsLevel::None, VcsLevel::None, VcsLevel::None, VcsLevel::Smart)?;
 
   if let Some(id) = id {
     mono.set_by_id(&id.parse()?, value)?;
-  } else if let Some(name) = name {
+  } else if let NameMatch::Partial(name) = name {
     mono.set_by_name(name, value)?;
+  } else if let NameMatch::Exact(name) = name {
+    mono.set_by_exact_name(name, value)?;
   } else {
     mono.set_by_only(value)?;
   }
@@ -182,8 +187,8 @@ pub async fn template(early_info: &EarlyInfo, template: &str) -> Result<()> {
 }
 
 pub fn info(
-  pref_vcs: Option<VcsRange>, ids: Vec<ProjectId>, names: Vec<&str>, labels: Vec<&str>, show: InfoShow,
-  ignore_current: bool
+  pref_vcs: Option<VcsRange>, ids: Vec<ProjectId>, names: Vec<&str>, exacts: Vec<&str>, labels: Vec<&str>,
+  show: InfoShow, ignore_current: bool
 ) -> Result<()> {
   let mono = with_opts(pref_vcs, VcsLevel::None, VcsLevel::Smart, VcsLevel::None, VcsLevel::Smart, ignore_current)?;
   let output = Output::new();
@@ -202,7 +207,8 @@ pub fn info(
         .iter()
         .filter(|p| {
           ids.contains(p.id())
-            || names.contains(&p.name())
+            || names.iter().any(|n| p.name().contains(n))
+            || exacts.contains(&p.name())
             || p.labels().iter().any(|l| labels.iter().any(|ll| ll == l))
         })
         .map(|p| ProjLine::from(p, reader))
@@ -452,4 +458,22 @@ pub fn failed_hashes(plan: &Plan) -> String {
   }
 
   commits
+}
+
+pub enum NameMatch {
+  Partial(String),
+  Exact(String),
+  None
+}
+
+impl NameMatch {
+  pub fn from(part: Option<&str>, exact: Option<&str>) -> NameMatch {
+    if let Some(n) = part {
+      NameMatch::Partial(n.to_string())
+    } else if let Some(n) = exact {
+      NameMatch::Exact(n.to_string())
+    } else {
+      NameMatch::None
+    }
+  }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,6 +160,15 @@ impl<S: StateRead> Config<S> {
     Ok(id)
   }
 
+  pub fn find_exact(&self, name: &str) -> Result<&ProjectId> {
+    let mut iter = self.file.projects.iter().filter(|p| p.name == name).map(|p| p.id());
+    let id = iter.next().ok_or_else(|| bad!("No project named {}", name))?;
+    if iter.next().is_some() {
+      bail!("Multiple projects with name {}", name);
+    }
+    Ok(id)
+  }
+
   pub fn annotate(&self) -> Result<Vec<AnnotatedMark>> {
     self.file.projects.iter().map(|p| p.annotate(&self.state)).collect()
   }

--- a/src/mono.rs
+++ b/src/mono.rs
@@ -124,6 +124,11 @@ impl Mono {
     self.set_by_id(&id, val)
   }
 
+  pub fn set_by_exact_name(&mut self, name: &str, val: &str) -> Result<()> {
+    let id = self.current.find_exact(name)?.clone();
+    self.set_by_id(&id, val)
+  }
+
   pub fn set_by_only(&mut self, val: &str) -> Result<()> {
     if self.current.projects().len() != 1 {
       bail!("No solo project.");


### PR DESCRIPTION
Add an "exact" flag for the "get", "set", and "info" commands, which will exactly match a project name, which can be used instead of "name" which matches a partial name.