### PR TITLE
fix: allow missing `auth` in prefs.toml

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -159,7 +159,7 @@ impl Repo {
     }
   }
 
-  pub fn github_info(&self, auth: &Auth) -> Result<GithubInfo> {
+  pub fn github_info(&self, auth: &Option<Auth>) -> Result<GithubInfo> {
     find_github_info(self.repo()?, self.remote_name()?, auth)
   }
 
@@ -934,7 +934,7 @@ fn find_branch_name(repo: &Repository) -> Result<Option<String>> {
   }
 }
 
-fn find_github_info(repo: &Repository, remote_name: &str, auth: &Auth) -> Result<GithubInfo> {
+fn find_github_info(repo: &Repository, remote_name: &str, auth: &Option<Auth>) -> Result<GithubInfo> {
   let remote = repo.find_remote(remote_name)?;
 
   let url = remote.url().ok_or_else(|| bad!("Invalid utf8 remote url."))?;
@@ -951,7 +951,8 @@ fn find_github_info(repo: &Repository, remote_name: &str, auth: &Auth) -> Result
   let slash = path.char_indices().find(|(_, c)| *c == '/').map(|(i, _)| i);
   let slash = slash.ok_or_else(|| bad!("No slash found in github path \"{}\".", path))?;
 
-  Ok(GithubInfo::new(path[0 .. slash].to_string(), path[slash + 1 ..].to_string(), auth.github_token().clone()))
+  let token = auth.as_ref().and_then(|auth| auth.github_token().clone());
+  Ok(GithubInfo::new(path[0 .. slash].to_string(), path[slash + 1 ..].to_string(), token))
 }
 
 /// Hide ancestors of `from` from the revwalk, but don't hide anything if the commit-ish can't be found and

--- a/src/github.rs
+++ b/src/github.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// rebase). The squash commit is excluded from all PRs: instead the PR's own commits are examined normally. In
 /// this way, the original type and size information from the PR is preserved.
 #[allow(clippy::map_entry)]
-pub async fn changes(auth: &Auth, repo: &Repo, baseref: FromTagBuf, headref: String) -> Result<Changes> {
+pub async fn changes(auth: &Option<Auth>, repo: &Repo, baseref: FromTagBuf, headref: String) -> Result<Changes> {
   let mut all_commits = HashSet::new();
   let mut all_prs = HashMap::new();
 

--- a/src/mono.rs
+++ b/src/mono.rs
@@ -212,7 +212,9 @@ impl Mono {
 fn read_env_prefs() -> Result<UserPrefs> {
   read_user_prefs().map(|mut prefs| {
     if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-      prefs.auth_mut().set_github_token(Some(token))
+      if let Some(auth) = prefs.auth_mut() {
+        auth.set_github_token(Some(token))
+      }
     }
     prefs
   })
@@ -234,12 +236,12 @@ fn read_user_prefs() -> Result<UserPrefs> {
 
 #[derive(Deserialize, Debug, Default)]
 struct UserPrefs {
-  auth: Auth
+  auth: Option<Auth>
 }
 
 impl UserPrefs {
-  fn auth(&self) -> &Auth { &self.auth }
-  fn auth_mut(&mut self) -> &mut Auth { &mut self.auth }
+  fn auth(&self) -> &Option<Auth> { &self.auth }
+  fn auth_mut(&mut self) -> &mut Option<Auth> { &mut self.auth }
 }
 
 /// Find the last covering commit ID, if any, for each current project.
@@ -416,7 +418,7 @@ struct PlanBuilder<'s> {
 }
 
 impl<'s> PlanBuilder<'s> {
-  fn create(repo: &'s Repo, current: &'s ConfigFile, auth: &Auth) -> PlanBuilder<'s> {
+  fn create(repo: &'s Repo, current: &'s ConfigFile, auth: &Option<Auth>) -> PlanBuilder<'s> {
     let prev = Slicer::init(repo);
     let github_info = repo.github_info(auth).ok();
     PlanBuilder {


### PR DESCRIPTION
This will allow the `prefs.toml` preferences file to be missing the `auth` section: if no `auth` section is found, Versio behaves the same way as if the section was empty.

Fixes: #25 