### PR TITLE
Add more hooks

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -390,10 +390,29 @@ relative to the base of the repo; other paths are relative to that root
     arbitrary labels to you projects, which is useful when using the
     `info` command.
   - `hooks`: (optional) A set of hooks that run at certain points of the
-    release process. Currently, only the `post_write` hook is supported:
-    this hook runs after local file changes are made, but before any VCS
-    commits/push/tagging is performed; it's useful to make additional
-    file changes that need to be committed with the release.
+    release process. Hooks are not run if the `dry-run` or
+    `changelog-only` flags are set. Note that commits, tags, and other
+    release operations are not executed on a project-by-project basis,
+    so all project hooks of the same type will be run together. Here are
+    the hooks you can use:
+    - `pre_begin`: runs before any other release activity is performed.
+      You can use this hook to perform any preperation for the release
+      process.
+    - `pre_write`: runs before any data is written to the local
+      filesystem; you can use this to prep files or record the fs state.
+    - `post_write`: runs after local file changes are made,
+      but before any VCS commits/push/tagging is performed; it's useful
+      to make additional file changes that need to be committed with the
+      release.
+    - `post_commit`: runs after local file changes are committed and/or
+      pushed to the VCS, but before tags are added/changed. Use this if
+      you want to perform additional VCS operations before tagging.
+    - `post_tag`: runs after tags are added/changed and pushed to the
+      VCS. Useful if you want to add your own tags, or perform final VCS
+      operations.
+    - `post_end`: runs after any other release activity. Use this if you
+      have cleanup operations that you want to run after your release is
+      done.
 
 - `commit`
 

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -145,6 +145,31 @@ directories or files listed in any `.gitignore` files. If you want to
 include projects in hidden or ignored locations, you'll have to add
 those by hand to the resulting `.versio.yaml` file.
 
+## Perform a Release
+
+This is the most commonly-used command: `release` will scan for
+conventional commits, increment all project version numbers accordingly,
+update changelogs, add and move tags, and commit and push all changes.
+
+```
+$ versio release
+```
+
+### Release dry-run
+
+You can run `versio -l local -c release -d` to run a "dry-run" release,
+which won't actually write or commit anything, but will print out the
+new version numbers that are expected. Using `-l local -c` will cause
+versio to run only on the local repository, and ignore problems with
+local changes: no network or remote operations will be consulted (see
+[VCS Levels](./vcs_levels.md)). This command can be used while
+performing edits to see that changes have the expected effect on a
+project version.
+
+Note that the actual release may calculate different version numbers
+than any given dry-run, especially if the configuration, network, or
+commit/PR history is different than found in the dry-run environment.
+
 ## Gitflow / Oneflow
 
 If you're using
@@ -286,6 +311,7 @@ jobs:
         run: versio check
       - name: Print changes
         run: versio plan
+      - any other pr actions...
 ```
 
 ## CI Release
@@ -325,4 +351,5 @@ jobs:
         run: git fetch --unshallow
       - name: Generate release
         run: versio release
+      - any other release actions...
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -783,7 +783,12 @@ impl HookSet {
     Ok(())
   }
 
+  pub fn execute_pre_begin(&self, root: &Option<&String>) -> Result<()> { self.execute("pre_begin", root) }
+  pub fn execute_pre_write(&self, root: &Option<&String>) -> Result<()> { self.execute("pre_write", root) }
   pub fn execute_post_write(&self, root: &Option<&String>) -> Result<()> { self.execute("post_write", root) }
+  pub fn execute_post_commit(&self, root: &Option<&String>) -> Result<()> { self.execute("post_commit", root) }
+  pub fn execute_post_tag(&self, root: &Option<&String>) -> Result<()> { self.execute("post_tag", root) }
+  pub fn execute_post_end(&self, root: &Option<&String>) -> Result<()> { self.execute("post_end", root) }
 }
 
 impl<'de> Deserialize<'de> for HookSet {

--- a/src/git.rs
+++ b/src/git.rs
@@ -50,6 +50,7 @@ impl Repo {
   // returns successfully at the Smart level.
 
   pub fn commit_config(&self) -> &CommitConfig { &self.commit_config }
+  pub fn root(&self) -> &Path { self.vcs.root() }
 
   /// Return the vcs level that this repository can support.
   pub fn detect<P: AsRef<Path>>(path: P) -> Result<VcsLevel> {
@@ -820,6 +821,15 @@ impl GitVcsLevel {
       VcsLevel::Local => GitVcsLevel::Local { repo, branch_name },
       VcsLevel::Remote => GitVcsLevel::Remote { repo, branch_name, remote_name, fetches },
       VcsLevel::Smart => GitVcsLevel::Smart { repo, branch_name, remote_name, fetches }
+    }
+  }
+
+  fn root(&self) -> &Path {
+    match self {
+      Self::None { root } => root,
+      Self::Local { repo, .. } => repo.workdir().unwrap(),
+      Self::Remote { repo, .. } => repo.workdir().unwrap(),
+      Self::Smart { repo, .. } => repo.workdir().unwrap()
     }
   }
 }


### PR DESCRIPTION
This adds additional hooks to the runtime, which (just like the existing `post_write` hook) will not run on a dry run.

Hooks added:
- pre_begin : runs before everything
- pre_write : runs jjust before writing files
- post_commit : runs after commits/push, but before tags
- post_tag : runs after tagging
- post_end : runs after everything